### PR TITLE
Fix bug #1069 and fix download onceConnected call

### DIFF
--- a/lib/menus/commands.js
+++ b/lib/menus/commands.js
@@ -391,8 +391,8 @@ const init = () => {
         $treeSelected.each((key, elem) => {
           const path = elem.getPath ? elem.getPath() : '';
           const localPath = path.replace(client.root.local, '');
-          const remotePath = Path.posix.normalize(atom.project.remoteftp.root.remote + localPath.replace(/\\/g, '/'));
-
+          const remotePath = Path.posix.normalize((atom.project.remoteftp.root.remote + localPath).replace(/\\/g, '/'));
+ 
           client.download(remotePath, true, () => {
             if (atom.config.get('Remote-FTP.notifications.enableTransfer')) {
               // TODO: check if any errors were thrown, indicating an unsuccessful transfer

--- a/lib/menus/commands.js
+++ b/lib/menus/commands.js
@@ -374,7 +374,7 @@ const init = () => {
 
           atom.commands.dispatch(viewWorkspace, 'remote-ftp:connect');
 
-          client.onceConnected('connected', () => {
+          atom.project.remoteftp.onceConnected(() => {
             atom.commands.dispatch(viewWorkspace, 'remote-ftp:download-selected-local');
           });
 
@@ -391,7 +391,7 @@ const init = () => {
         $treeSelected.each((key, elem) => {
           const path = elem.getPath ? elem.getPath() : '';
           const localPath = path.replace(client.root.local, '');
-          const remotePath = Path.posix.normalize(atom.project.remoteftp.root.remote + localPath);
+          const remotePath = Path.posix.normalize(atom.project.remoteftp.root.remote + localPath.replace(/\\/g, '/'));
 
           client.download(remotePath, true, () => {
             if (atom.config.get('Remote-FTP.notifications.enableTransfer')) {


### PR DESCRIPTION
Just replacing \ with / on localPath for now.

There seems to be no way to ask the FTP server what the preferred directory separator is, see https://stackoverflow.com/questions/37411642/how-to-get-ftp-servers-file-separator. As noted there, most FTP servers will use / however some do not. Perhaps in the future we should add an option to .ftpconfig to specify the FTP server's preferred directory separator, with / being the default. That way in obscure situations the user can specify whatever separator they want.

I also noticed that it wasn't triggering the download after connecting (if not connected at time of request), so put in a quick fix for that as well